### PR TITLE
Chores/fix templates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 htmlcov
+*.html

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,11 @@
+[MASTER]
+
+load-plugins=pylint_django
+
+[MESSAGES CONTROL]
+
+disable=missing-docstring,
+        redefined-outer-name,
+        invalid-name,
+        no-self-use,
+        wrong-import-order

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ coverage = "*"
 ipython = "*"
 faker = "*"
 factory-boy = "*"
+pylint-django = "*"
 
 [packages]
 Django = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "93b713fec054ce5c2e240c866f55895c477628b2fecbbacf4c4fb141cc751bd5"
+            "sha256": "c9a916b643e9c95f653503acf5d548556f31aa04b3e4d7da845c7b6c560b02da"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -82,14 +82,6 @@
         }
     },
     "develop": {
-        "appnope": {
-            "hashes": [
-                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
-                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
-            ],
-            "markers": "sys_platform == 'darwin'",
-            "version": "==0.1.0"
-        },
         "aspy.yaml": {
             "hashes": [
                 "sha256:ae249074803e8b957c83fdd82a99160d0d6d26dff9ba81ba608b42eebd7d8cd3",
@@ -106,10 +98,10 @@
         },
         "awsebcli": {
             "hashes": [
-                "sha256:579fc405c36a64ac600f186107152beca986bdb18f201b2d830e2119ead658dd"
+                "sha256:1e4b2ae9ffbcb3d9b04f34d95a6e6935099bf3458305f3db294eee0a159150fa"
             ],
             "index": "pypi",
-            "version": "==3.15.0"
+            "version": "==3.15.1"
         },
         "backcall": {
             "hashes": [
@@ -127,10 +119,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:54a1671d42b4ab3effcada7d2c13b7264509b7993b6cf9e2faac8cfafe1e1b3a",
-                "sha256:8eb5720e16994dde3fab8ae5ddb352fb4dd97be723969f081b58d45c74f3804e"
+                "sha256:5e4774c106bb02f8e4639818c2f8157b8ec114a76e481e17cd3fe6955206e088",
+                "sha256:cfc667e7888aad09ead8f7e32129ea90aa5c7f602531094954bf6305db74aac4"
             ],
-            "version": "==1.12.148"
+            "version": "==1.12.151"
         },
         "cached-property": {
             "hashes": [
@@ -302,10 +294,10 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2f2e54cbf6b06b16351e4c40a6adb0860cab6cfb95a0c0fcb58bb789c4b450f5",
-                "sha256:37bbea81dec44d1ff72d58a1b5c1599a9f3436537f33e9e26f276610064c4830"
+                "sha256:0e375a4c177090292988d1c2f997c7c2467d908c1adbed3e08fb511486c85457",
+                "sha256:440815529340fb7fdd6a83ebf4258cc2860fb3770d37b52875e37c6f509a4cd6"
             ],
-            "version": "==0.12"
+            "version": "==0.13"
         },
         "ipython": {
             "hashes": [
@@ -498,6 +490,7 @@
                 "sha256:5dc5f85caef2c5f9e61622b9cbd89d94edd3dcf546939b2974d18de4fa90d676",
                 "sha256:bf313f10b68ed915a34f0f475cc9ff8c7f574a95302beb48b79c5993f7efd84c"
             ],
+            "index": "pypi",
             "version": "==2.0.2"
         },
         "pylint-flask": {
@@ -619,10 +612,10 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:15ee248d13e4001a691d9583948ad3947bcb8a289775102e4c4aa98a8b7a6d73",
-                "sha256:bfc98bb9b42a3029ee41b96dc00a34c2f254cbf7716bec824477b2c82741a5c4"
+                "sha256:99acaf1e35c7ccf9763db9ba2accbca2f4254d61d1912c5ee364f9cc4a8942a0",
+                "sha256:fe51cdbf04e5d8152af06c075404745a7419de27495a83f0d72518ad50be3ce8"
             ],
-            "version": "==16.5.0"
+            "version": "==16.6.0"
         },
         "wcwidth": {
             "hashes": [
@@ -654,10 +647,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:46dfd547d9ccbf8bdc26ecea52818046bb28509f12bb6a0de1cd66ab06e9a9be",
-                "sha256:d7ac25f895fb65bff937b381353c14eb1fa23d35f40abd72a5342cd57eb57fd1"
+                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
+                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
             ],
-            "version": "==0.5.0"
+            "version": "==0.5.1"
         }
     }
 }

--- a/fec/templates/fec/campaign.html
+++ b/fec/templates/fec/campaign.html
@@ -17,10 +17,10 @@
   {%for campaign in similar_campaigns%}
   <li>
     <a href="{% url 'campaign' campaign.id %}">
-      {{ campaign.name }} ({{ campaign.party_abbreviation }}) {{ campaign.state
-      }}
+      {{ campaign.name }}
+      ({{ campaign.party_abbreviation }})
+      {{ campaign.state }}
     </a>
-    {{ campaign.contributor_count }}
   </li>
   {%endfor%}
 </ul>
@@ -38,8 +38,9 @@
 {%for contribution in contributions%}
 <p>{{ contribution.contributor.contributor_name }}</p>
 <p>
-  ${{ contribution.amount }} | {{ contribution.date }} | {{
-  contribution.committee.name }}
+  ${{ contribution.amount }} |
+  {{ contribution.date }} |
+  {{ contribution.committee.name }}
 </p>
 {%endfor%}
 

--- a/fec/test_models.py
+++ b/fec/test_models.py
@@ -97,34 +97,31 @@ class ContributersTest(TestCase):
             contributor_occupation='PHYSICIAN')
 
     def test_nickname_matches_given(self):
-        self.givenname = Contributor(
+        givenname = Contributor(
             contributor_name='SMITH MD., JUDITH R',
             contributor_city='Manchester',
             contributor_state='NH',
             contributor_zip='03104',
             contributor_employer='Self',
             contributor_occupation='PHYSICIAN')
-        self.assertEqual(self.nickname.id,
-                         Contributor.search(self.givenname)[0].id)
+        self.assertEqual(self.nickname.id, Contributor.search(givenname)[0].id)
 
     def test_nickname_matches_short(self):
-        self.short = Contributor(
+        short = Contributor(
             contributor_name='SMITH, JUDY',
             contributor_city='Manchester',
             contributor_state='NH',
             contributor_zip='03104',
             contributor_employer='Self',
             contributor_occupation='PHYSICIAN')
-        self.assertEqual(self.nickname.id,
-                         Contributor.search(self.short)[0].id)
+        self.assertEqual(self.nickname.id, Contributor.search(short)[0].id)
 
     def test_nickname_matches_nickname(self):
-        self.nickname2 = Contributor(
+        nickname2 = Contributor(
             contributor_name='SMITH, JUDY MD.',
             contributor_city='Manchester',
             contributor_state='NH',
             contributor_zip='03104',
             contributor_employer='Self',
             contributor_occupation='PHYSICIAN')
-        self.assertEqual(self.nickname.id,
-                         Contributor.search(self.nickname2)[0].id)
+        self.assertEqual(self.nickname.id, Contributor.search(nickname2)[0].id)


### PR DESCRIPTION
# Problem

Looks like prettier is doing bad things to our Django templates, where it's adding newlines inside of
`{{ interpolations }}`, which breaks rendering (see screenshots)

# Solution

Turn off prettier for html files, and fix the broken interpolations.

Also, I was having some weird pylint errors. Adding django-pylint and ignoring a few rules seemed to fix them up.

## Screenshot (Optional)

### Before

![bad](https://user-images.githubusercontent.com/5178425/59028939-c99f6980-8811-11e9-8ec9-5ea9ea2f213d.png)

### After 

![good](https://user-images.githubusercontent.com/5178425/59028938-c99f6980-8811-11e9-9080-e25e87478d27.png)
